### PR TITLE
Add configuration block for gem parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,15 @@ Or install it yourself as:
 
 ## Usage
 
-**TODO:** Write usage instructions here
+How to configure:
+```ruby
+Dc::Metrics.configure do |config|
+  config.caller = ''
+  config.env = ''
+  config.gcp_project_id = ''
+  config.pubsub_topic_name = ''
+end
+```
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -33,12 +33,14 @@ Or install it yourself as:
 How to configure:
 ```ruby
 Dc::Metrics.configure do |config|
-  config.caller = ''
-  config.env = ''
-  config.gcp_project_id = ''
-  config.pubsub_topic_name = ''
+  config.caller            = 'application_name'
+  config.env               = 'test'
+  config.gcp_project_id    = 'project_id'
+  config.pubsub_topic_name = 'topic_name'
 end
 ```
+
+Obs: If there are missing parameters in this configuration the lib will fail to execute and output message to stdout! No exception is raised.
 
 ## Development
 

--- a/lib/dc/metrics.rb
+++ b/lib/dc/metrics.rb
@@ -1,12 +1,25 @@
 require "dc/metrics/version"
+require "dc/metrics/configuration"
 
 module Dc
   module Metrics
     class Error < StandardError; end
     # Your code goes here...
 
-    def self.hello
-      puts 'Hello World!'
+    class << self
+      attr_accessor :configuration
+    end
+
+    def self.configuration
+      @configuration ||= Configuration.new
+    end
+
+    def self.reset
+      @configuration = Configuration.new
+    end
+
+    def self.configure
+      yield(configuration)
     end
   end
 end

--- a/lib/dc/metrics/configuration.rb
+++ b/lib/dc/metrics/configuration.rb
@@ -1,0 +1,14 @@
+module Dc
+  module Metrics
+    class Configuration
+      attr_accessor :caller, :env, :gcp_project_id, :pubsub_topic_name
+
+      def initialize
+        @caller = nil
+        @env = nil
+        @gcp_project_id = nil
+        @pubsub_topic_name = nil
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,4 +11,13 @@ RSpec.configure do |config|
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end
+
+  config.before(:all) do
+    Dc::Metrics.configure do |config|
+      config.caller            = 'application_name'
+      config.env               = 'test'
+      config.gcp_project_id    = 'project_id'
+      config.pubsub_topic_name = 'topic_name'
+    end
+  end
 end


### PR DESCRIPTION
Added configuration parameters as a block following what is accepted by [Elixir lib](https://github.com/deliverycenter/dc.libs.metrics.elixir) and [Go lang lib](https://github.com/deliverycenter/dc.libs.metrics.golang).
```ruby
Dc::Metrics.configure do |config|
  config.caller = ''
  config.env = ''
  config.gcp_project_id = ''
  config.pubsub_topic_name = ''
end
```